### PR TITLE
Change version to 2.0.1 in pacakge.json in example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "preinstall": "npm pack ..",
-    "install-root": "npm run pack-root && npm install react-native-youtube-2.0.0.tgz",
+    "install-root": "npm run pack-root && npm install react-native-youtube-2.0.1.tgz",
     "reinstall-native-ios": "npm run install-root && npm run postinstall",
     "postinstall": "cd ios && pod install && cd ..",
     "clean": "rimraf ios/build ios/Pods android/.gradle android/app/build package-lock.json yarn-lock.json node_modules",
@@ -19,7 +19,7 @@
     "prettier": "^2.0.4",
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-youtube": "file:react-native-youtube-2.0.0.tgz",
+    "react-native-youtube": "file:react-native-youtube-2.0.1.tgz",
     "rimraf": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Not really sure, however, since the version of react-native-youtube is 2.0.1, the `npm pack ..` command packs a `react-native-youtube-2.0.1.tgz` file for us. The version in package.json in example should be modified, too.

Otherwise, error be thrown out like this
```
npm ERR! code ENOENT
npm ERR! syscall stat
npm ERR! path /Users/user/Documents/react-native-youtube/example/react-native-youtube-2.0.0.tgz
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, stat '/Users/user/Documents/react-native-youtube/example/react-native-youtube-2.0.0.tgz'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/user/.npm/_logs/2020-05-09T16_58_41_447Z-debug.log
```