### PR TITLE
fix(types): Add missing apiKey type inside YouTubeProps

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
 
 export interface YouTubeProps {
+  apiKey: string;
   videoId?: string;
   videoIds?: string[];
   playlistId?: string;


### PR DESCRIPTION
apiKey is missing in types. Its a mandatory prop.