### PR TITLE
Add flags support for fullscreen control.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Open AppDelegate.m and add :
   play // control playback of video with true/false
   fullscreen // control whether the video should play in fullscreen or inline
   loop // control whether the video should loop when ended
-  onReady={e => this.setState({ isReady: true })}
-  onChangeState={e => this.setState({ status: e.state })}
-  onChangeQuality={e => this.setState({ quality: e.quality })}
-  onError={e => this.setState({ error: e.error })}
+  onReady={(e) => this.setState({ isReady: true })}
+  onChangeState={(e) => this.setState({ status: e.state })}
+  onChangeQuality={(e) => this.setState({ quality: e.quality })}
+  onError={(e) => this.setState({ error: e.error })}
   style={{ alignSelf: 'stretch', height: 300 }}
 />
 ```
@@ -78,6 +78,7 @@ import YouTube from 'react-native-youtube';
 - `loop` (boolean): Loops the video. Default: `false`.
 - `fullscreen` (boolean): Controls whether the video should play inline or in fullscreen. Default: `false`.
 - `controls` (number): Sets the player's controls scheme. Supported values are `0`, `1`, `2`. Default: `1`. On iOS the numbers conform to [These Parameters](https://developers.google.com/youtube/player_parameters?hl=en#controls). On Android the mapping is `0 = CHROMELESS`, `1 = DEFAULT`, `2 = MINIMAL` ([More Info](https://developers.google.com/youtube/android/player/reference/com/google/android/youtube/player/YouTubePlayer.PlayerStyle)).
+- `fullscreenControlsFlags` (number): Set's player fullscreen control flags on Android. Available flags are `FULLSCREEN_FLAG_CONTROL_ORIENTATION`, `FULLSCREEN_FLAG_CONTROL_SYSTEM_UI`, `FULLSCREEN_FLAG_ALWAYS_FULLSCREEN_IN_LANDSCAPE` and `FULLSCREEN_FLAG_CUSTOM_LAYOUT` ([More Info](<https://developers.google.com/youtube/android/player/reference/com/google/android/youtube/player/YouTubePlayer.html#setFullscreenControlFlags(int)>))
 - `showFullscreenButton` (boolean): Show or hide Fullscreen button. Default: `true`.
 - `showinfo` (boolean, _iOS_): Setting the parameter's value to false causes the player to not display information like the video title and uploader before the video starts playing. Default: `true`.
 - `modestbranding` (boolean, _iOS_): This parameter lets you use a YouTube player that does not show a YouTube logo. Default: `false`.
@@ -127,8 +128,8 @@ import { YouTubeStandaloneIOS } from 'react-native-youtube';
 
 ```javascript
 YouTubeStandaloneIOS.playVideo('KVZ-P-ZI6W4')
-  .then(message => console.log(message))
-  .catch(errorMessage => console.error(errorMessage));
+  .then((message) => console.log(message))
+  .catch((errorMessage) => console.error(errorMessage));
 ```
 
 #### `YouTubeStandaloneIOS.playVideo(videoId)` (Static)
@@ -155,7 +156,7 @@ YouTubeStandaloneAndroid.playVideo({
   startTime: 120, // Starting point of video (in seconds)
 })
   .then(() => console.log('Standalone Player Exited'))
-  .catch(errorMessage => console.error(errorMessage));
+  .catch((errorMessage) => console.error(errorMessage));
 ```
 
 #### `YouTubeStandaloneAndroid.playVideo(options)` (Static)

--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -31,6 +31,7 @@ export default class YouTube extends React.Component {
     loop: PropTypes.bool,
     fullscreen: PropTypes.bool,
     controls: PropTypes.oneOf([0, 1, 2]),
+    fullscreenControlFlags: PropTypes.number,
     showFullscreenButton: PropTypes.bool,
     resumePlayAndroid: PropTypes.bool,
     onError: PropTypes.func,
@@ -45,6 +46,14 @@ export default class YouTube extends React.Component {
     showFullscreenButton: true,
     resumePlayAndroid: true,
   };
+
+  static FULLSCREEN_FLAG_CONTROL_ORIENTATION =
+    NativeModules.YouTubeModule.FULLSCREEN_FLAG_CONTROL_ORIENTATION;
+  static FULLSCREEN_FLAG_CONTROL_SYSTEM_UI =
+    NativeModules.YouTubeModule.FULLSCREEN_FLAG_CONTROL_SYSTEM_UI;
+  static FULLSCREEN_FLAG_ALWAYS_FULLSCREEN_IN_LANDSCAPE =
+    NativeModules.YouTubeModule.FULLSCREEN_FLAG_ALWAYS_FULLSCREEN_IN_LANDSCAPE;
+  static FULLSCREEN_FLAG_CUSTOM_LAYOUT = NativeModules.YouTubeModule.FULLSCREEN_FLAG_CUSTOM_LAYOUT;
 
   _interval = null;
 

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
@@ -3,9 +3,8 @@ package com.inprogress.reactnativeyoutube;
 import androidx.annotation.Nullable;
 
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.common.MapBuilder;
-import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
@@ -31,16 +30,16 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
     }
 
     @Override
-    public Map<String,Integer> getCommandsMap() {
+    public Map<String, Integer> getCommandsMap() {
         return MapBuilder.of(
-            "seekTo",
-            COMMAND_SEEK_TO,
-            "nextVideo",
-            COMMAND_NEXT_VIDEO,
-            "previousVideo",
-            COMMAND_PREVIOUS_VIDEO,
-            "playVideoAt",
-            COMMAND_PLAY_VIDEO_AT
+                "seekTo",
+                COMMAND_SEEK_TO,
+                "nextVideo",
+                COMMAND_NEXT_VIDEO,
+                "previousVideo",
+                COMMAND_PREVIOUS_VIDEO,
+                "playVideoAt",
+                COMMAND_PLAY_VIDEO_AT
         );
     }
 
@@ -67,24 +66,25 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
             }
             default:
                 throw new IllegalArgumentException(
-                  String.format("Unsupported command %d received by %s.", commandType, getClass().getSimpleName())
+                        String.format("Unsupported command %d received by %s.", commandType, getClass().getSimpleName())
                 );
         }
     }
 
     @Override
-    public @Nullable Map <String,Object> getExportedCustomDirectEventTypeConstants() {
+    public @Nullable
+    Map<String, Object> getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.of(
-            "error",
-            (Object) MapBuilder.of("registrationName", "onYouTubeError"),
-            "ready",
-            (Object) MapBuilder.of("registrationName", "onYouTubeReady"),
-            "state",
-            (Object) MapBuilder.of("registrationName", "onYouTubeChangeState"),
-            "quality",
-            (Object) MapBuilder.of("registrationName", "onYouTubeChangeQuality"),
-            "fullscreen",
-            (Object) MapBuilder.of("registrationName", "onYouTubeChangeFullscreen")
+                "error",
+                (Object) MapBuilder.of("registrationName", "onYouTubeError"),
+                "ready",
+                (Object) MapBuilder.of("registrationName", "onYouTubeReady"),
+                "state",
+                (Object) MapBuilder.of("registrationName", "onYouTubeChangeState"),
+                "quality",
+                (Object) MapBuilder.of("registrationName", "onYouTubeChangeQuality"),
+                "fullscreen",
+                (Object) MapBuilder.of("registrationName", "onYouTubeChangeFullscreen")
         );
     }
 
@@ -133,6 +133,11 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
     @ReactProp(name = "fullscreen")
     public void setPropFullscreen(YouTubeView view, @Nullable boolean param) {
         view.setFullscreen(param);
+    }
+
+    @ReactProp(name = "fullscreenControlFlags")
+    public void setPropFullscreenControlFlags(YouTubeView view, int flags) {
+        view.setFullscreenControlFlags(flags);
     }
 
     @ReactProp(name = "controls")

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
@@ -1,5 +1,7 @@
 package com.inprogress.reactnativeyoutube;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -8,6 +10,10 @@ import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.google.android.youtube.player.YouTubePlayer;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 public class YouTubeModule extends ReactContextBaseJavaModule {
@@ -31,7 +37,7 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
         try {
             UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
             uiManager.addUIBlock(new UIBlock() {
-                public void execute (NativeViewHierarchyManager nvhm) {
+                public void execute(NativeViewHierarchyManager nvhm) {
                     YouTubeView youTubeView = (YouTubeView) nvhm.resolveView(reactTag);
                     YouTubeManager youTubeManager = (YouTubeManager) nvhm.resolveViewManager(reactTag);
                     int index = youTubeManager.getVideosIndex(youTubeView);
@@ -48,7 +54,7 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
         try {
             UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
             uiManager.addUIBlock(new UIBlock() {
-                public void execute (NativeViewHierarchyManager nvhm) {
+                public void execute(NativeViewHierarchyManager nvhm) {
                     YouTubeView youTubeView = (YouTubeView) nvhm.resolveView(reactTag);
                     YouTubeManager youTubeManager = (YouTubeManager) nvhm.resolveViewManager(reactTag);
                     int currentTime = youTubeManager.getCurrentTime(youTubeView);
@@ -65,7 +71,7 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
         try {
             UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
             uiManager.addUIBlock(new UIBlock() {
-                public void execute (NativeViewHierarchyManager nvhm) {
+                public void execute(NativeViewHierarchyManager nvhm) {
                     YouTubeView youTubeView = (YouTubeView) nvhm.resolveView(reactTag);
                     YouTubeManager youTubeManager = (YouTubeManager) nvhm.resolveViewManager(reactTag);
                     int duration = youTubeManager.getDuration(youTubeView);
@@ -75,5 +81,16 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
         } catch (IllegalViewOperationException e) {
             promise.reject(E_MODULE_ERROR, e);
         }
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getConstants() {
+        Map<String, Object> constants = new HashMap<>();
+        constants.put("FULLSCREEN_FLAG_CONTROL_ORIENTATION", YouTubePlayer.FULLSCREEN_FLAG_CONTROL_ORIENTATION);
+        constants.put("FULLSCREEN_FLAG_CONTROL_SYSTEM_UI", YouTubePlayer.FULLSCREEN_FLAG_CONTROL_SYSTEM_UI);
+        constants.put("FULLSCREEN_FLAG_ALWAYS_FULLSCREEN_IN_LANDSCAPE", YouTubePlayer.FULLSCREEN_FLAG_ALWAYS_FULLSCREEN_IN_LANDSCAPE);
+        constants.put("FULLSCREEN_FLAG_CUSTOM_LAYOUT", YouTubePlayer.FULLSCREEN_FLAG_CUSTOM_LAYOUT);
+        return constants;
     }
 }

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
@@ -1,18 +1,16 @@
 package com.inprogress.reactnativeyoutube;
 
+import android.os.Handler;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
-import android.os.Handler;
 
+import com.facebook.react.bridge.ReadableArray;
 import com.google.android.youtube.player.YouTubeInitializationResult;
 import com.google.android.youtube.player.YouTubePlayer;
 
-import com.facebook.react.bridge.ReadableArray;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.lang.Runnable;
 
 
 public class YouTubePlayerController implements
@@ -24,6 +22,8 @@ public class YouTubePlayerController implements
     private YouTubePlayer mYouTubePlayer;
     private YouTubeView mYouTubeView;
 
+    private int FLAGS_NONE = -1;
+
     private static final int VIDEO_MODE = 0;
     private static final int VIDEOS_MODE = 1;
     private static final int PLAYLIST_MODE = 2;
@@ -32,6 +32,8 @@ public class YouTubePlayerController implements
     private boolean mIsReady = false;
     private int mMode = 0;
     private int mVideosIndex = 0;
+
+    private int mFullscreenControlFlags = FLAGS_NONE;
 
     private String mVideoId = null;
     private List<String> mVideoIds = new ArrayList<String>();
@@ -54,6 +56,7 @@ public class YouTubePlayerController implements
             mYouTubePlayer.setPlayerStateChangeListener(this);
             mYouTubePlayer.setPlaybackEventListener(this);
             mYouTubePlayer.setOnFullscreenListener(this);
+            updateFullscreenControlFlags();
             updateFullscreen();
             updateShowFullscreenButton();
             updateControls();
@@ -162,11 +165,11 @@ public class YouTubePlayerController implements
     }
 
     public int getCurrentTime() {
-      return mYouTubePlayer.getCurrentTimeMillis() / 1000;
+        return mYouTubePlayer.getCurrentTimeMillis() / 1000;
     }
 
     public int getDuration() {
-      return mYouTubePlayer.getDurationMillis() / 1000;
+        return mYouTubePlayer.getDurationMillis() / 1000;
     }
 
     public void nextVideo() {
@@ -241,6 +244,12 @@ public class YouTubePlayerController implements
         mYouTubePlayer.setFullscreen(mFullscreen);
     }
 
+    private void updateFullscreenControlFlags() {
+        if (mFullscreenControlFlags != -1) {
+            mYouTubePlayer.setFullscreenControlFlags(mFullscreenControlFlags);
+        }
+    }
+
     private void updateShowFullscreenButton() {
         mYouTubePlayer.setShowFullscreenButton(mShowFullscreenButton);
     }
@@ -312,7 +321,7 @@ public class YouTubePlayerController implements
             handler.postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                   mYouTubePlayer.play();
+                    mYouTubePlayer.play();
                 }
             }, 1);
         }
@@ -378,6 +387,11 @@ public class YouTubePlayerController implements
     public void setFullscreen(boolean fullscreen) {
         mFullscreen = fullscreen;
         if (isLoaded()) updateFullscreen();
+    }
+
+    public void setFullscreenControlFlags(int flags) {
+        mFullscreenControlFlags = flags;
+        if (isLoaded()) updateFullscreenControlFlags();
     }
 
     public void setControls(int controls) {

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -3,8 +3,9 @@ package com.inprogress.reactnativeyoutube;
 import android.app.FragmentManager;
 import android.os.Build;
 import android.os.Parcelable;
-import androidx.annotation.Nullable;
 import android.widget.FrameLayout;
+
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
@@ -183,6 +184,10 @@ public class YouTubeView extends FrameLayout {
 
     public void setFullscreen(boolean bool) {
         mYouTubeController.setFullscreen(bool);
+    }
+
+    public void setFullscreenControlFlags(int flags) {
+        mYouTubeController.setFullscreenControlFlags(flags);
     }
 
     public void setControls(int nb) {

--- a/main.d.ts
+++ b/main.d.ts
@@ -12,6 +12,7 @@ export interface YouTubeProps {
   showinfo?: boolean;
   modestbranding?: boolean;
   showFullscreenButton?: boolean;
+  fullscreenControlFlags?: number;
   rel?: boolean;
   origin?: string;
   onError?: (event: any) => void;
@@ -32,6 +33,11 @@ declare class YouTube extends React.Component<YouTubeProps> {
   getCurrentTime(): Promise<number>;
   getDuration(): Promise<number>;
   reloadIframe(): void;
+
+  static FULLSCREEN_FLAG_CONTROL_ORIENTATION?: number;
+  static FULLSCREEN_FLAG_CONTROL_SYSTEM_UI?: number;
+  static FULLSCREEN_FLAG_ALWAYS_FULLSCREEN_IN_LANDSCAPE?: number;
+  static FULLSCREEN_FLAG_CUSTOM_LAYOUT?: number;
 }
 
 export declare const YouTubeStandaloneIOS: {


### PR DESCRIPTION
In Android, YouTubePlayer provides developers with option to set FullscreenControlFlags, that helps us define default behaviour for orientation change or declare that we'll use custom one. Those are not currently exposed to RN, while it seems useful.

Please refer to [YouTube Documentation](https://developers.google.com/youtube/android/player/reference/com/google/android/youtube/player/YouTubePlayer.html#setFullscreenControlFlags(int)).