### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/RCTYouTube.podspec
+++ b/RCTYouTube.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source         = { :git => package_json["repository"]["url"].gsub(/(http.*)/).first, :tag => "v#{s.version}" }
   s.source_files   = "RCTYouTube*.{h,m}"
   s.preserve_paths = "*.js"
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "YoutubePlayer-in-WKWebView", "~> 0.3.1"
 
 end


### PR DESCRIPTION
Compilation fails on Xcode 12 with `Undefined symbols for architecture` errors, due to the React dependency in the podspec.

See the react-native issue here - https://github.com/facebook/react-native/issues/29633#issuecomment-694187116