### PR TITLE
iOS: Fix seekTo to support float type second

### DIFF
--- a/YouTube.ios.js
+++ b/YouTube.ios.js
@@ -116,7 +116,7 @@ export default class YouTube extends React.Component {
   };
 
   seekTo(seconds) {
-    NativeModules.YouTubeManager.seekTo(ReactNative.findNodeHandle(this), parseInt(seconds, 10));
+    NativeModules.YouTubeManager.seekTo(ReactNative.findNodeHandle(this), parseFloat(seconds, 10));
   }
 
   nextVideo() {


### PR DESCRIPTION
Current version cannot be moved accurately using `seekTo` in iOS.

e.g. seekTo(3) and seekTo(3.8) have the same result

So, I changed `parseInt` to `parseFloat` in `seekTo` method (Youtube.ios.js)

I checked it works good in iPhone simulator

