### PR TITLE
Updated onChangeState and onChangeQuality callbacks arguments

### DIFF
--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeStandaloneModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeStandaloneModule.java
@@ -40,15 +40,19 @@ public class YouTubeStandaloneModule extends ReactContextBaseJavaModule {
             if (requestCode == REQ_START_STANDALONE_PLAYER) {
                 if (mPickerPromise != null) {
                     if (resultCode != Activity.RESULT_OK) {
-                        YouTubeInitializationResult errorReason =
-                            YouTubeStandalonePlayer.getReturnedInitializationResult(intent);
-                        if (errorReason.isUserRecoverableError()) {
-                            errorReason.getErrorDialog(activity, requestCode).show();
-                            mPickerPromise.reject(E_PLAYER_ERROR);
-                        } else {
-                            String errorMessage =
-                                String.format("There was an error initializing the YouTubePlayer (%1$s)", errorReason.toString());
-                            mPickerPromise.reject(E_PLAYER_ERROR, errorMessage);
+                        try {
+                            YouTubeInitializationResult errorReason =
+                                YouTubeStandalonePlayer.getReturnedInitializationResult(intent);
+                            if (errorReason.isUserRecoverableError()) {
+                                errorReason.getErrorDialog(activity, requestCode).show();
+                                mPickerPromise.reject(E_PLAYER_ERROR);
+                            } else {
+                                String errorMessage =
+                                    String.format("There was an error initializing the YouTubePlayer (%1$s)", errorReason.toString());
+                                mPickerPromise.reject(E_PLAYER_ERROR, errorMessage);
+                            }
+                        } catch(RuntimeException e) {
+                            mPickerPromise.reject(E_PLAYER_ERROR, e);
                         }
                     } else {
                         mPickerPromise.resolve(null);

--- a/main.d.ts
+++ b/main.d.ts
@@ -16,8 +16,8 @@ export interface YouTubeProps {
   origin?: string;
   onError?: (event: any) => void;
   onReady?: (event: any) => void;
-  onChangeState?: () => void;
-  onChangeQuality?: () => void;
+  onChangeState?: (event: any) => void;
+  onChangeQuality?: (event: any) => void;
   onChangeFullscreen?: (event: any) => void;
   onProgress?: (event: any) => void;
   style?: StyleProp<ViewStyle>;

--- a/tests/type-test.tsx
+++ b/tests/type-test.tsx
@@ -34,8 +34,8 @@ const YouTubeTest = () => {
       origin={'foo'}
       onError={(event) => {}}
       onReady={(event) => {}}
-      onChangeState={() => {}}
-      onChangeQuality={() => {}}
+      onChangeState={(event) => {}}
+      onChangeQuality={(event) => {}}
       onChangeFullscreen={(event) => {}}
       onProgress={() => {}}
       style={{ flex: 1 }}

--- a/tests/type-test.tsx
+++ b/tests/type-test.tsx
@@ -37,7 +37,7 @@ const YouTubeTest = () => {
       onChangeState={(event) => {}}
       onChangeQuality={(event) => {}}
       onChangeFullscreen={(event) => {}}
-      onProgress={() => {}}
+      onProgress={(event) => {}}
       style={{ flex: 1 }}
     />
   );


### PR DESCRIPTION
As mentioned on [this issue](https://github.com/davidohayon669/react-native-youtube/issues/471), `onChangeState `and `onChangeQuality` callbacks are defined as `() => void` in [main.d.ts](https://github.com/davidohayon669/react-native-youtube/blob/master/main.d.ts#L19) even though they do receive event arguments like all the other event callbacks. I don't know if it was outdated or simply incorrect, but I updated their definitions anyway. Please let me know if these differences were intended. :)

Also, I've included an "event" argument on the value of `onProgress` prop in [type-test.tsx](https://github.com/davidohayon669/react-native-youtube/blob/master/tests/type-test.tsx#L40).