### PR TITLE
added mavenCentral() for gradle builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
+        mavenCentral()
         google()
         jcenter()
     }


### PR DESCRIPTION
As jCenter is shutting down so adding mavenCentral() so that gradle builds fail