### PR TITLE
Handling RuntimeException thrown by YouTubeStandalonePlayer.getReturnedInitializationResult

### DIFF
--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeStandaloneModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeStandaloneModule.java
@@ -40,15 +40,19 @@ public class YouTubeStandaloneModule extends ReactContextBaseJavaModule {
             if (requestCode == REQ_START_STANDALONE_PLAYER) {
                 if (mPickerPromise != null) {
                     if (resultCode != Activity.RESULT_OK) {
-                        YouTubeInitializationResult errorReason =
-                            YouTubeStandalonePlayer.getReturnedInitializationResult(intent);
-                        if (errorReason.isUserRecoverableError()) {
-                            errorReason.getErrorDialog(activity, requestCode).show();
-                            mPickerPromise.reject(E_PLAYER_ERROR);
-                        } else {
-                            String errorMessage =
-                                String.format("There was an error initializing the YouTubePlayer (%1$s)", errorReason.toString());
-                            mPickerPromise.reject(E_PLAYER_ERROR, errorMessage);
+                        try {
+                            YouTubeInitializationResult errorReason =
+                                YouTubeStandalonePlayer.getReturnedInitializationResult(intent);
+                            if (errorReason.isUserRecoverableError()) {
+                                errorReason.getErrorDialog(activity, requestCode).show();
+                                mPickerPromise.reject(E_PLAYER_ERROR);
+                            } else {
+                                String errorMessage =
+                                    String.format("There was an error initializing the YouTubePlayer (%1$s)", errorReason.toString());
+                                mPickerPromise.reject(E_PLAYER_ERROR, errorMessage);
+                            }
+                        } catch(RuntimeException e) {
+                            mPickerPromise.reject(E_PLAYER_ERROR, e);
                         }
                     } else {
                         mPickerPromise.resolve(null);

--- a/main.d.ts
+++ b/main.d.ts
@@ -16,8 +16,8 @@ export interface YouTubeProps {
   origin?: string;
   onError?: (event: any) => void;
   onReady?: (event: any) => void;
-  onChangeState?: () => void;
-  onChangeQuality?: () => void;
+  onChangeState?: (event: any) => void;
+  onChangeQuality?: (event: any) => void;
   onChangeFullscreen?: (event: any) => void;
   onProgress?: (event: any) => void;
   style?: StyleProp<ViewStyle>;

--- a/tests/type-test.tsx
+++ b/tests/type-test.tsx
@@ -34,8 +34,8 @@ const YouTubeTest = () => {
       origin={'foo'}
       onError={(event) => {}}
       onReady={(event) => {}}
-      onChangeState={() => {}}
-      onChangeQuality={() => {}}
+      onChangeState={(event) => {}}
+      onChangeQuality={(event) => {}}
       onChangeFullscreen={(event) => {}}
       onProgress={() => {}}
       style={{ flex: 1 }}

--- a/tests/type-test.tsx
+++ b/tests/type-test.tsx
@@ -37,7 +37,7 @@ const YouTubeTest = () => {
       onChangeState={(event) => {}}
       onChangeQuality={(event) => {}}
       onChangeFullscreen={(event) => {}}
-      onProgress={() => {}}
+      onProgress={(event) => {}}
       style={{ flex: 1 }}
     />
   );


### PR DESCRIPTION
I've noticed that when you have more than one app that can launch a standalone player for YouTube, your app will present a dialog for you to choose which app do you wish to use. If you close the dialog without choosing an option, the YoutubeStandaloneModule throws a RuntimeException that is not handled by the lib causing the app to crash.

Therefore I've wrapped the block inside a try catch and rejected the promise if the runtime error occurs.

I also fixed a few type definitions.