### PR TITLE
chore(types): fix wrong types declaration

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -17,8 +17,8 @@ export interface YouTubeProps {
   origin?: string;
   onError?: (event: any) => void;
   onReady?: (event: any) => void;
-  onChangeState?: () => void;
-  onChangeQuality?: () => void;
+  onChangeState?: (event: any) => void;
+  onChangeQuality?: (event: any) => void;
   onChangeFullscreen?: (event: any) => void;
   onProgress?: (event: any) => void;
   style?: StyleProp<ViewStyle>;
@@ -57,7 +57,7 @@ export declare const YouTubeStandaloneAndroid: {
   }): Promise<void>;
   playPlaylist(params: {
     apiKey: string;
-    playlistId: string[];
+    playlistId: string;
     autoplay?: boolean;
     lightboxMode?: boolean;
     startIndex?: number;


### PR DESCRIPTION
Fix wrong types declaration for `YoutubeProps`:

- `onChangeState`: add `event` parameter
- `onChangeQuality`: add `event` parameter

Fix wrong types declaration for `YouTubeStandaloneAndroid`:

- `playPlaylist`: set `playlistId` to `string` instead of `string[]`