### PR TITLE
Fix ViewPropTypes deprecation error

### DIFF
--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactNative, {
   View,
-  ViewPropTypes,
   Text,
   StyleSheet,
   requireNativeComponent,
@@ -10,6 +9,8 @@ import ReactNative, {
   NativeModules,
   BackHandler,
 } from 'react-native';
+
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 const RCTYouTube = requireNativeComponent('ReactYouTube', YouTube, {
   nativeOnly: {

--- a/YouTube.ios.js
+++ b/YouTube.ios.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactNative, { requireNativeComponent, NativeModules, ViewPropTypes } from 'react-native';
+import ReactNative, { requireNativeComponent, NativeModules } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 const RCTYouTube = requireNativeComponent('RCTYouTube', null);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/davidohayon669/react-native-youtube",
   "dependencies": {
-    "prop-types": "^15.5.0"
+    "prop-types": "^15.5.0",
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "peerDependencies": {
     "react-native": ">=0.60"


### PR DESCRIPTION
Using `react-native-youtube` v2.0.2 with RN v0.69 leads to the following error:

`ERROR  Invariant Violation: ViewPropTypes has been removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'`

This PR fixes the import statements as suggested.